### PR TITLE
NAC-433: Add Local Packages page to Admin Console

### DIFF
--- a/nuxeo-admin-console-web/angular-app/src/app/app-routing.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/app-routing.module.ts
@@ -77,6 +77,14 @@ export const appRoutes: Route[] = [
             "./features/configuration-details/configuration-details.module"
           ).then((m) => m.ConfigurationDetailsModule),
     },
+    {
+      path: "local-packages",
+      title: routeTitle.LOCAL_PACKAGES,
+      loadChildren: () =>
+        import("./features/local-packages/local-packages.module").then(
+          (m) => m.LocalPackagesModule
+        ),
+    },
   { path: "**", redirectTo: "" },
 ];
 

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages-routing.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { LocalPackagesComponent } from "./local-packages.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: LocalPackagesComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class LocalPackagesRoutingModule {}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.html
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.html
@@ -1,0 +1,147 @@
+<div class="local-packages">
+  <h5 class="local-packages__title">{{ LOCAL_PACKAGES_LABELS.TITLE }}</h5>
+
+  <!-- Loading State -->
+  @if (!isDataLoaded && !isError) {
+  <div class="loading-container">
+    <mat-spinner [diameter]="50"></mat-spinner>
+    <p>{{ LOCAL_PACKAGES_LABELS.LOADING_MSG }}</p>
+  </div>
+  }
+
+  <!-- Error State -->
+  @if (isError) {
+  <div class="error-container">
+    <h3>{{ LOCAL_PACKAGES_LABELS.API_FAILURE_MESSAGE }}</h3>
+    <button mat-raised-button color="primary" (click)="getLocalPackages()">
+      {{ LOCAL_PACKAGES_LABELS.RETRY_BTN_LABEL }}
+    </button>
+  </div>
+  }
+
+  <!-- No Data State -->
+  @if (isDataLoaded && !isError && !hasPackages()) {
+  <div class="no-data-container">
+    <h3>{{ LOCAL_PACKAGES_LABELS.NO_DATA_MSG }}</h3>
+  </div>
+  }
+
+  <!-- Data Available State -->
+  @if (isDataLoaded && !isError && hasPackages()) {
+  <mat-card role="region" aria-label="local-packages" tabindex="0">
+    <mat-card-content>
+      <div class="table-container">
+        <table
+          mat-table
+          [dataSource]="packages"
+          class="mat-elevation-z0"
+          aria-label="Local Packages Table"
+        >
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef sticky>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.NAME }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{ row?.name || LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="title">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.TITLE }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{ row?.title || LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="version">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.VERSION }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{ row?.version || LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="type">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.TYPE }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{ row?.type || LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="state">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.STATE }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              @if (row?.state) {
+              <span
+                class="state-badge"
+                [ngClass]="'state-badge--' + row.state.toLowerCase()"
+                >{{ row.state }}</span
+              >
+              } @else {
+              <span>{{ LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="vendor">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.VENDOR }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{ row?.vendor || LOCAL_PACKAGES_LABELS.EMPTY_VALUE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="targetPlatforms">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{
+                LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.TARGET_PLATFORMS
+              }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <span>{{
+                row?.targetPlatforms?.length
+                  ? row.targetPlatforms.join(", ")
+                  : LOCAL_PACKAGES_LABELS.EMPTY_VALUE
+              }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="description">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{
+                LOCAL_PACKAGES_LABELS.COLUMN_HEADERS.DESCRIPTION
+              }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let row" class="description-cell">
+              <span>{{
+                row?.description || LOCAL_PACKAGES_LABELS.EMPTY_VALUE
+              }}</span>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="columnsToDisplay; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
+        </table>
+      </div>
+    </mat-card-content>
+    <mat-card-footer>
+      <mat-paginator
+        #paginator
+        [length]="packages.data.length || 0"
+        [pageSize]="10"
+        [pageSizeOptions]="[5, 10, 25, 100]"
+        aria-label="Select page"
+      >
+      </mat-paginator>
+    </mat-card-footer>
+  </mat-card>
+  }
+</div>

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.html
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.html
@@ -1,5 +1,7 @@
 <div class="local-packages">
+  @if (isDataLoaded && !isError && hasPackages()) {
   <h5 class="local-packages__title">{{ LOCAL_PACKAGES_LABELS.TITLE }}</h5>
+  }
 
   <!-- Loading State -->
   @if (!isDataLoaded && !isError) {

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.scss
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.scss
@@ -1,0 +1,147 @@
+.local-packages {
+  background-color: #f4f4f4;
+  padding: 20px;
+  height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__title {
+    margin: 0 0 16px 0;
+    flex-shrink: 0;
+  }
+}
+
+// Adjust to 100vh when viewport is small (zoomed in 200%+)
+@media (max-height: 600px) {
+  .local-packages {
+    height: 100vh;
+  }
+}
+
+mat-card {
+  flex: 1;
+  min-height: 300px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  &.mdc-card {
+    border-radius: 12px;
+    padding: 24px;
+    background: white;
+    border: 1px solid #d1d5db;
+    box-shadow: none;
+  }
+}
+
+.mat-mdc-card-content:first-child {
+  padding-top: 0;
+}
+
+.mat-mdc-card-content {
+  flex: 1;
+  width: 100%;
+  overflow: hidden;
+}
+
+.table-container {
+  height: 100%;
+  overflow: auto;
+}
+
+table {
+  width: 100%;
+}
+
+th,
+td {
+  padding-right: 16px;
+}
+
+.description-cell {
+  max-width: 320px;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.state-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  background-color: #e5e7eb;
+  color: #374151;
+
+  &--started {
+    background-color: #e3f4e8;
+    color: #1a7f37;
+  }
+
+  &--downloaded,
+  &--installed {
+    background-color: #e5effb;
+    color: #0560cb;
+  }
+
+  &--remote {
+    background-color: #fdecea;
+    color: #b3261e;
+  }
+}
+
+.loading-container,
+.error-container,
+.no-data-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  width: 100%;
+  text-align: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.error-container h3,
+.no-data-container h3 {
+  font-weight: 500;
+  font-size: 18px;
+  color: #666;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
+}
+
+.error-container {
+  h3 {
+    margin-bottom: 1.5rem;
+  }
+
+  button {
+    background-color: #0a60ce;
+    border-radius: 4px !important;
+    font-weight: 600;
+    font-family: "Open Sans", sans-serif;
+    letter-spacing: normal;
+  }
+}
+
+.no-data-container h3 {
+  margin: 0;
+}
+
+.loading-container {
+  mat-spinner {
+    margin-bottom: 1.5rem;
+  }
+
+  p {
+    margin: 0;
+    color: #666;
+    font-size: 16px;
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.spec.ts
@@ -1,0 +1,136 @@
+import { initializeTestBed } from "src/test-helpers"; //This import must be the first import in the file.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatDialogModule } from "@angular/material/dialog";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatPaginatorModule } from "@angular/material/paginator";
+import { MatTableModule } from "@angular/material/table";
+import { MatCardModule } from "@angular/material/card";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import {
+  HttpErrorResponse,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import { of, throwError } from "rxjs";
+import { LocalPackagesComponent } from "./local-packages.component";
+import { LocalPackagesService } from "./services/local-packages.service";
+import { SharedMethodsService } from "../../shared/services/shared-methods.service";
+import { ERROR_TYPES } from "../sub-features/generic-multi-feature-layout/generic-multi-feature-layout.constants";
+import { LocalPackagesResponse } from "../../shared/types/local-packages.interface";
+
+const mockResponse: LocalPackagesResponse = {
+  "entity-type": "packages",
+  entries: [
+    {
+      "entity-type": "package",
+      id: "nuxeo-web-ui-2025.12.0",
+      name: "nuxeo-web-ui",
+      title: "Nuxeo Web UI",
+      description: "Web UI package",
+      version: "2025.12.0",
+      type: "ADDON",
+      state: "STARTED",
+      targetPlatforms: [],
+      vendor: "Nuxeo",
+    },
+  ],
+};
+
+describe("LocalPackagesComponent", () => {
+  initializeTestBed();
+
+  let component: LocalPackagesComponent;
+  let fixture: ComponentFixture<LocalPackagesComponent>;
+  let localPackagesService: LocalPackagesService;
+  let sharedService: SharedMethodsService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LocalPackagesComponent],
+      imports: [
+        NoopAnimationsModule,
+        MatSnackBarModule,
+        MatDialogModule,
+        MatProgressSpinnerModule,
+        MatPaginatorModule,
+        MatTableModule,
+        MatCardModule,
+      ],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LocalPackagesComponent);
+    component = fixture.componentInstance;
+    localPackagesService = TestBed.inject(LocalPackagesService);
+    sharedService = TestBed.inject(SharedMethodsService);
+    vi.spyOn(localPackagesService, "getLocalPackages").mockReturnValue(
+      of({ "entity-type": "packages", entries: [] })
+    );
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should load packages on init and set them on the data source", async () => {
+    vi.spyOn(localPackagesService, "getLocalPackages").mockReturnValue(
+      of(mockResponse)
+    );
+    component.getLocalPackages();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.isError).toBe(false);
+    expect(component.packages.data).toEqual(mockResponse.entries);
+    expect(component.hasPackages()).toBe(true);
+  });
+
+  it("should handle an empty entries list", async () => {
+    vi.spyOn(localPackagesService, "getLocalPackages").mockReturnValue(
+      of({ "entity-type": "packages", entries: [] })
+    );
+    component.getLocalPackages();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.hasPackages()).toBe(false);
+  });
+
+  it("should handle error and call showActionErrorModal on failed fetch", async () => {
+    const mockError = new HttpErrorResponse({
+      error: { status: 500, message: "Server error" },
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+    vi.spyOn(localPackagesService, "getLocalPackages").mockReturnValue(
+      throwError(() => mockError)
+    );
+    const showErrorSpy = vi
+      .spyOn(sharedService, "showActionErrorModal")
+      .mockReturnValue(of(undefined));
+    component.getLocalPackages();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.isError).toBe(true);
+    expect(showErrorSpy).toHaveBeenCalledWith({
+      type: ERROR_TYPES.SERVER_ERROR,
+      details: {
+        status: 500,
+        message: "Server error",
+      },
+    });
+  });
+
+  it("should complete destroy$ subject on ngOnDestroy", () => {
+    const nextSpy = vi.spyOn(component.destroy$, "next");
+    const completeSpy = vi.spyOn(component.destroy$, "complete");
+    component.ngOnDestroy();
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+});

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.spec.ts
@@ -9,6 +9,7 @@ import { MatPaginatorModule } from "@angular/material/paginator";
 import { MatTableModule } from "@angular/material/table";
 import { MatCardModule } from "@angular/material/card";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { CommonModule } from "@angular/common";
 import {
   HttpErrorResponse,
   provideHttpClient,

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnDestroy, OnInit, ViewChild, inject } from "@angular/core";
 import { HttpErrorResponse } from "@angular/common/http";
-import { Subject } from "rxjs";
-import { takeUntil } from "rxjs/internal/operators/takeUntil";
+import { Subject, takeUntil } from "rxjs";
 import { MatPaginator } from "@angular/material/paginator";
 import { MatTableDataSource } from "@angular/material/table";
 import {

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnDestroy, OnInit, ViewChild, inject } from "@angular/core";
+import { HttpErrorResponse } from "@angular/common/http";
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/internal/operators/takeUntil";
+import { MatPaginator } from "@angular/material/paginator";
+import { MatTableDataSource } from "@angular/material/table";
+import {
+  LOCAL_PACKAGES_COLUMNS,
+  LOCAL_PACKAGES_LABELS,
+} from "./local-packages.constants";
+import { LocalPackagesService } from "./services/local-packages.service";
+import { SharedMethodsService } from "../../shared/services/shared-methods.service";
+import { ERROR_TYPES } from "../sub-features/generic-multi-feature-layout/generic-multi-feature-layout.constants";
+import { LocalPackage } from "../../shared/types/local-packages.interface";
+
+@Component({
+  selector: "app-local-packages",
+  templateUrl: "./local-packages.component.html",
+  styleUrls: ["./local-packages.component.scss"],
+  standalone: false,
+})
+export class LocalPackagesComponent implements OnInit, OnDestroy {
+  private localPackagesService = inject(LocalPackagesService);
+  private sharedService = inject(SharedMethodsService);
+  LOCAL_PACKAGES_LABELS = LOCAL_PACKAGES_LABELS;
+  columnsToDisplay = LOCAL_PACKAGES_COLUMNS;
+  packages: MatTableDataSource<LocalPackage> =
+    new MatTableDataSource<LocalPackage>([]);
+  isDataLoaded = false;
+  isError = false;
+  destroy$: Subject<void> = new Subject<void>();
+
+  // The table is rendered conditionally, so bind the paginator through a setter
+  // that fires once the table (and paginator) exist in the DOM.
+  @ViewChild("paginator") set paginator(paginator: MatPaginator) {
+    if (paginator) {
+      this.packages.paginator = paginator;
+    }
+  }
+
+  ngOnInit(): void {
+    this.getLocalPackages();
+  }
+
+  getLocalPackages(): void {
+    this.isDataLoaded = false;
+    this.isError = false;
+    this.localPackagesService
+      .getLocalPackages()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (data) => {
+          this.packages.data = data?.entries ?? [];
+          this.isDataLoaded = true;
+        },
+        error: (error: HttpErrorResponse) => {
+          this.isDataLoaded = true;
+          this.isError = true;
+          this.sharedService.showActionErrorModal({
+            type: ERROR_TYPES.SERVER_ERROR,
+            details: {
+              status: error?.error?.status || error?.status,
+              message: error?.error?.message || error?.message,
+            },
+          });
+        },
+      });
+  }
+
+  hasPackages(): boolean {
+    return this.packages.data.length > 0;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.constants.ts
@@ -1,0 +1,30 @@
+export const LOCAL_PACKAGES_LABELS = {
+  TITLE: "Local Packages",
+  LOADING_MSG: "Loading packages...",
+  API_FAILURE_MESSAGE:
+    "An error occurred while fetching the list of local packages.",
+  RETRY_BTN_LABEL: "Retry",
+  NO_DATA_MSG: "No local packages are installed.",
+  EMPTY_VALUE: "-",
+  COLUMN_HEADERS: {
+    NAME: "Name",
+    TITLE: "Title",
+    VERSION: "Version",
+    TYPE: "Type",
+    STATE: "State",
+    VENDOR: "Vendor",
+    TARGET_PLATFORMS: "Target Platforms",
+    DESCRIPTION: "Description",
+  },
+};
+
+export const LOCAL_PACKAGES_COLUMNS = [
+  "name",
+  "title",
+  "version",
+  "type",
+  "state",
+  "vendor",
+  "targetPlatforms",
+  "description",
+];

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/local-packages.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatCardModule } from "@angular/material/card";
+import { MatTableModule } from "@angular/material/table";
+import { MatPaginatorModule } from "@angular/material/paginator";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatButtonModule } from "@angular/material/button";
+import { LocalPackagesComponent } from "./local-packages.component";
+import { LocalPackagesRoutingModule } from "./local-packages-routing.module";
+
+@NgModule({
+  declarations: [LocalPackagesComponent],
+  imports: [
+    CommonModule,
+    LocalPackagesRoutingModule,
+    MatCardModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+  ],
+})
+export class LocalPackagesModule {}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.spec.ts
@@ -8,10 +8,12 @@ import {
   vi,
 } from "vitest";
 import { TestBed } from "@angular/core/testing";
+import { of } from "rxjs";
 import { LocalPackagesService } from "./local-packages.service";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { NetworkService } from "../../../shared/services/network.service";
 import { REST_END_POINTS } from "../../../shared/constants/rest-end-ponts.constants";
+import { LocalPackagesResponse } from "../../../shared/types/local-packages.interface";
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -24,8 +26,15 @@ describe("LocalPackagesService", () => {
   let networkService: MockedObject<NetworkService>;
 
   beforeEach(() => {
+    const mockResponse: LocalPackagesResponse = {
+      "entity-type": "packages",
+      entries: [],
+    };
     const spy = {
-      makeHttpRequest: vi.fn().mockName("NetworkService.makeHttpRequest"),
+      makeHttpRequest: vi
+        .fn()
+        .mockName("NetworkService.makeHttpRequest")
+        .mockReturnValue(of(mockResponse)),
     };
     TestBed.configureTestingModule({
       providers: [

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.spec.ts
@@ -1,0 +1,54 @@
+import { initializeTestBed } from "src/test-helpers"; //This import must be the first import in the file.
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockedObject,
+  vi,
+} from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { LocalPackagesService } from "./local-packages.service";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { NetworkService } from "../../../shared/services/network.service";
+import { REST_END_POINTS } from "../../../shared/constants/rest-end-ponts.constants";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+
+describe("LocalPackagesService", () => {
+  initializeTestBed();
+
+  let service: LocalPackagesService;
+  let networkService: MockedObject<NetworkService>;
+
+  beforeEach(() => {
+    const spy = {
+      makeHttpRequest: vi.fn().mockName("NetworkService.makeHttpRequest"),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        LocalPackagesService,
+        { provide: NetworkService, useValue: spy },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(LocalPackagesService);
+    networkService = TestBed.inject(
+      NetworkService
+    ) as MockedObject<NetworkService>;
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should call makeHttpRequest with the correct endpoint when getLocalPackages is called", () => {
+    service.getLocalPackages();
+    expect(networkService.makeHttpRequest).toHaveBeenCalledWith(
+      REST_END_POINTS.GET_LOCAL_PACKAGES
+    );
+  });
+});

--- a/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/local-packages/services/local-packages.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, inject } from "@angular/core";
+import { Observable } from "rxjs";
+import { LocalPackagesResponse } from "../../../shared/types/local-packages.interface";
+import { REST_END_POINTS } from "../../../shared/constants/rest-end-ponts.constants";
+import { NetworkService } from "../../../shared/services/network.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class LocalPackagesService {
+  private networkService = inject(NetworkService);
+
+  getLocalPackages(): Observable<LocalPackagesResponse> {
+    return this.networkService.makeHttpRequest<LocalPackagesResponse>(
+      REST_END_POINTS.GET_LOCAL_PACKAGES
+    );
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/layouts/menu-bar/menu-bar.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/layouts/menu-bar/menu-bar.constants.ts
@@ -61,6 +61,12 @@ export const ADMIN_MENU: Menu[] = [
     path: "configuration-properties",
     isSelected: false,
   },
+  {
+    id: 10,
+    name: "Local Packages",
+    path: "local-packages",
+    isSelected: false,
+  },
 ];
 
 export const ROUTES_TITLE = {
@@ -72,4 +78,5 @@ export const ROUTES_TITLE = {
   PICTURE_RENDITIONS: "Picture Renditions",
   STREAM_MANAGEMENT: "Stream Management",
   CONFIGURATION_DETAILS: "Configuration Properties",
+  LOCAL_PACKAGES: "Local Packages",
 };

--- a/nuxeo-admin-console-web/angular-app/src/app/shared/constants/rest-end-ponts.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/shared/constants/rest-end-ponts.constants.ts
@@ -24,6 +24,7 @@ export const REST_END_POINTS = {
   GET_SCALING_ANALYSIS: "GET_SCALING_ANALYSIS",
   GET_STREAM_PROCESSOR_INFO: "GET_STREAM_PROCESSOR_INFO",
   GET_CONFIGURATION_DETAILS: "GET_CONFIGURATION_DETAILS",
+  GET_LOCAL_PACKAGES: "GET_LOCAL_PACKAGES",
 } as const;
 
 type RestEndpointKey = keyof typeof REST_END_POINTS;
@@ -136,6 +137,11 @@ export const REST_END_POINT_CONFIG: Record<
 
   GET_CONFIGURATION_DETAILS: {
     endpoint: "/management/configuration",
+    method: "GET",
+  },
+
+  GET_LOCAL_PACKAGES: {
+    endpoint: "/management/distribution/packages",
     method: "GET",
   },
 };

--- a/nuxeo-admin-console-web/angular-app/src/app/shared/types/local-packages.interface.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/shared/types/local-packages.interface.ts
@@ -1,0 +1,23 @@
+export interface LocalPackage {
+  "entity-type"?: string;
+  id: string;
+  name: string;
+  title: string;
+  description?: string;
+  version: string;
+  type: string;
+  state: string;
+  targetPlatforms?: string[];
+  vendor?: string;
+  supportsHotReload?: boolean;
+  provides?: string[];
+  dependencies?: string[];
+  conflicts?: string[];
+  licenseType?: string;
+  licenseUrl?: string;
+}
+
+export interface LocalPackagesResponse {
+  "entity-type"?: string;
+  entries: LocalPackage[];
+}


### PR DESCRIPTION
New lazy-loaded feature that fetches GET /management/distribution/packages via NetworkService (no NgRx) and renders installed packages in a Material table with loading/success/empty/error states. Adds sidenav item, route, REST endpoint constant, and typed interfaces. Includes unit tests.