### PR TITLE
NAC-432: Display bundles list in Admin Console

### DIFF
--- a/nuxeo-admin-console-web/angular-app/src/app/app-routing.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/app-routing.module.ts
@@ -77,6 +77,12 @@ export const appRoutes: Route[] = [
             "./features/configuration-details/configuration-details.module"
           ).then((m) => m.ConfigurationDetailsModule),
     },
+    {
+      path: "bundles",
+      title: routeTitle.BUNDLES,
+      loadChildren: () =>
+        import("./features/bundles/bundles.module").then((m) => m.BundlesModule),
+    },
   { path: "**", redirectTo: "" },
 ];
 

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles-routing.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { BundlesComponent } from "./bundles.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: BundlesComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class BundlesRoutingModule {}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.html
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.html
@@ -1,0 +1,131 @@
+<div class="bundles">
+  <h1 id="page-title" aria-live="polite">{{ BUNDLES_LABELS.TITLE }}</h1>
+
+  <!-- Loading State -->
+  @if (!isDataLoaded && !isError) {
+  <div class="loading-container">
+    <mat-spinner [diameter]="50"></mat-spinner>
+    <p>{{ BUNDLES_LABELS.LOADING_MSG }}</p>
+  </div>
+  }
+
+  <!-- Error State -->
+  @if (isError) {
+  <div class="error-container">
+    <h3>{{ BUNDLES_LABELS.API_FAILURE_MESSAGE }}</h3>
+    <button mat-raised-button color="primary" (click)="getBundles()">
+      {{ BUNDLES_LABELS.RETRY_BTN_LABEL }}
+    </button>
+  </div>
+  }
+
+  <!-- No Data State -->
+  @if (isDataLoaded && !isError && !hasBundles()) {
+  <div class="no-data-container">
+    <h3>{{ BUNDLES_LABELS.NO_DATA_MSG }}</h3>
+  </div>
+  }
+
+  <!-- Data Available State -->
+  @if (isDataLoaded && !isError && hasBundles()) {
+  <mat-card class="bundles__card" role="region" [attr.aria-label]="BUNDLES_LABELS.DISTRIBUTION_TITLE" tabindex="0">
+    <mat-card-content>
+      <h2>{{ BUNDLES_LABELS.DISTRIBUTION_TITLE }}</h2>
+      <dl class="bundles__summary">
+        @for (field of distributionSummary; track field.label) {
+        <div class="bundles__summary-item">
+          <dt>{{ field.label }}</dt>
+          <dd>{{ field.value }}</dd>
+        </div>
+        }
+      </dl>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card class="bundles__card" role="region" [attr.aria-label]="BUNDLES_LABELS.TITLE" tabindex="0">
+    <mat-card-content>
+      <div class="bundles__table-header">
+        <h2>
+          {{ buildLabelWithCount(BUNDLES_LABELS.BUNDLES_COUNT, bundlesData.data.length) }}
+        </h2>
+        <mat-form-field appearance="outline" class="input-field bundles__filter">
+          <mat-label>{{ BUNDLES_LABELS.FILTER_LABEL }}</mat-label>
+          <input matInput id="bundles-filter" type="text" [placeholder]="BUNDLES_LABELS.FILTER_PLACEHOLDER"
+            (input)="applyFilter($event)" />
+        </mat-form-field>
+      </div>
+
+      <div class="bundles__table-container">
+        <table mat-table [dataSource]="bundlesData" class="mat-elevation-z0" aria-label="Bundles Table">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef sticky>
+              <strong>{{ BUNDLES_LABELS.COLUMN_HEADERS.NAME }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let bundle">
+              <span>{{ bundle?.name }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="version">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ BUNDLES_LABELS.COLUMN_HEADERS.VERSION }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let bundle">
+              <span>{{ bundle?.version || BUNDLES_LABELS.NOT_AVAILABLE }}</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="revision">
+            <th mat-header-cell *matHeaderCellDef>
+              <strong>{{ BUNDLES_LABELS.COLUMN_HEADERS.REVISION }}</strong>
+            </th>
+            <td mat-cell *matCellDef="let bundle">
+              <span>{{ bundle?.revision || BUNDLES_LABELS.NOT_AVAILABLE }}</span>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="columnsToDisplay; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: columnsToDisplay" tabindex="0"></tr>
+        </table>
+
+        @if (!hasFilteredBundles()) {
+        <p class="bundles__no-match" aria-live="polite">
+          {{ BUNDLES_LABELS.NO_MATCHING_BUNDLES_MSG }}
+        </p>
+        }
+      </div>
+    </mat-card-content>
+    <mat-card-footer>
+      <mat-paginator [length]="bundlesData.filteredData.length" [pageSize]="pageSize"
+        [pageSizeOptions]="pageSizeOptions" aria-label="Select page">
+      </mat-paginator>
+    </mat-card-footer>
+  </mat-card>
+
+  @if (warnings.length > 0) {
+  <mat-card class="bundles__card" role="region" aria-label="Bundle warnings" tabindex="0">
+    <mat-card-content>
+      <h2>{{ buildLabelWithCount(BUNDLES_LABELS.WARNINGS_TITLE, warnings.length) }}</h2>
+      <ul class="bundles__messages bundles__messages--warning">
+        @for (warning of warnings; track $index) {
+        <li>{{ warning?.message }}</li>
+        }
+      </ul>
+    </mat-card-content>
+  </mat-card>
+  }
+
+  @if (errors.length > 0) {
+  <mat-card class="bundles__card" role="region" aria-label="Bundle errors" tabindex="0">
+    <mat-card-content>
+      <h2>{{ buildLabelWithCount(BUNDLES_LABELS.ERRORS_TITLE, errors.length) }}</h2>
+      <ul class="bundles__messages bundles__messages--error">
+        @for (error of errors; track $index) {
+        <li>{{ error?.message }}</li>
+        }
+      </ul>
+    </mat-card-content>
+  </mat-card>
+  }
+  }
+</div>

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.html
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.html
@@ -33,10 +33,8 @@
       <h2>{{ BUNDLES_LABELS.DISTRIBUTION_TITLE }}</h2>
       <dl class="bundles__summary">
         @for (field of distributionSummary; track field.label) {
-        <div class="bundles__summary-item">
-          <dt>{{ field.label }}</dt>
-          <dd>{{ field.value }}</dd>
-        </div>
+        <dt>{{ field.label }}</dt>
+        <dd>{{ field.value }}</dd>
         }
       </dl>
     </mat-card-content>
@@ -51,7 +49,7 @@
         <mat-form-field appearance="outline" class="input-field bundles__filter">
           <mat-label>{{ BUNDLES_LABELS.FILTER_LABEL }}</mat-label>
           <input matInput id="bundles-filter" type="text" [placeholder]="BUNDLES_LABELS.FILTER_PLACEHOLDER"
-            (input)="applyFilter($event)" />
+            [attr.aria-label]="BUNDLES_LABELS.FILTER_LABEL" (input)="applyFilter($event)" />
         </mat-form-field>
       </div>
 

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
@@ -1,0 +1,167 @@
+.bundles {
+  background-color: #f4f4f4;
+  margin: 0px;
+  padding: 20px;
+  min-height: 100%;
+  box-sizing: border-box;
+
+  h1 {
+    font-size: 20px;
+    font-weight: 500;
+    width: fit-content;
+  }
+
+  h2 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+  }
+
+  &__card {
+    margin-bottom: 20px;
+
+    &.mdc-card {
+      border-radius: 12px;
+      padding: 24px;
+      background: white;
+      border: 1px solid #d1d5db;
+      box-shadow: none;
+    }
+  }
+
+  &__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin: 0;
+  }
+
+  &__summary-item {
+    dt {
+      color: #666;
+      font-size: 13px;
+      margin-bottom: 4px;
+    }
+
+    dd {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 600;
+      word-break: break-word;
+    }
+  }
+
+  &__table-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  &__filter {
+    width: 320px;
+    max-width: 100%;
+  }
+
+  &__table-container {
+    max-height: 550px;
+    overflow: auto;
+  }
+
+  &__no-match {
+    padding: 24px;
+    text-align: center;
+    color: #666;
+    font-size: 16px;
+    margin: 0;
+  }
+
+  &__messages {
+    margin: 0;
+    padding-left: 20px;
+
+    li {
+      font-size: 14px;
+      margin-bottom: 8px;
+      word-break: break-word;
+    }
+
+    &--warning li {
+      color: #8a6100;
+    }
+
+    &--error li {
+      color: #b3261e;
+    }
+  }
+
+  table {
+    width: 100%;
+  }
+
+  tr:focus {
+    outline: none;
+    background: #e5effb;
+  }
+}
+
+.mat-mdc-card-content:first-child {
+  padding-top: 0;
+}
+
+.loading-container,
+.error-container,
+.no-data-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  text-align: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.error-container h3,
+.no-data-container h3 {
+  font-weight: 500;
+  font-size: 18px;
+  color: #666;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
+}
+
+.error-container button {
+  background-color: #0a60ce;
+  border-radius: 4px !important;
+  font-weight: 600;
+  font-family: "Open Sans", sans-serif;
+  margin-top: 1rem;
+  letter-spacing: normal;
+}
+
+.loading-container {
+  mat-spinner {
+    margin-bottom: 1.5rem;
+  }
+
+  p {
+    margin: 0;
+    color: #666;
+    font-size: 16px;
+  }
+}
+
+.error-container {
+  h3 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.no-data-container {
+  h3 {
+    margin: 0;
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
@@ -49,7 +49,7 @@
       margin: 0;
       font-size: 14px;
       font-weight: 600;
-      word-break: break-word;
+      overflow-wrap: break-word;
     }
   }
 
@@ -86,7 +86,7 @@
     li {
       font-size: 14px;
       margin-bottom: 8px;
-      word-break: break-word;
+      overflow-wrap: break-word;
     }
 
     &--warning li {

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.scss
@@ -31,16 +31,18 @@
 
   &__summary {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 16px;
+    grid-template-columns: max-content 1fr max-content 1fr;
+    gap: 12px 16px;
+    align-items: baseline;
     margin: 0;
-  }
 
-  &__summary-item {
+    @media (max-width: 900px) {
+      grid-template-columns: max-content 1fr;
+    }
+
     dt {
       color: #666;
       font-size: 13px;
-      margin-bottom: 4px;
     }
 
     dd {

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.spec.ts
@@ -1,0 +1,255 @@
+import { initializeTestBed } from "src/test-helpers"; //This import must be the first import in the file.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import {
+  HttpErrorResponse,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { MatCardModule } from "@angular/material/card";
+import { MatDialogModule } from "@angular/material/dialog";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import {
+  MatPaginator,
+  MatPaginatorModule,
+  PageEvent,
+} from "@angular/material/paginator";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatTableModule } from "@angular/material/table";
+import { Subject, of, throwError } from "rxjs";
+import { BundlesComponent } from "./bundles.component";
+import { BundlesService } from "./services/bundles.service";
+import { BUNDLES_LABELS } from "./bundles.constants";
+import { DistributionResponse } from "../../shared/types/bundles.interface";
+import { SharedMethodsService } from "../../shared/services/shared-methods.service";
+import { ERROR_TYPES } from "../sub-features/generic-multi-feature-layout/generic-multi-feature-layout.constants";
+
+const mockDistribution: DistributionResponse = {
+  "entity-type": "serverInfo",
+  applicationName: "Nuxeo Platform",
+  applicationVersion: "2025.1.0",
+  distributionName: "server",
+  distributionVersion: "2025.1.0",
+  distributionDate: "2025-01-15 10:23",
+  bundles: [
+    { name: "org.nuxeo.ecm.core", version: "2025.1.0", revision: "abc1234" },
+    { name: "org.nuxeo.ecm.platform.picture.core", version: "2025.1.0" },
+  ],
+  warnings: [{ message: "A component was overridden" }],
+  errors: [{ message: "A contribution failed to load" }],
+};
+
+/* MatTableDataSource subscribes to the paginator streams as soon as it is
+assigned, so the stub has to expose them. */
+const createPaginatorStub = () =>
+  ({
+    page: new Subject<PageEvent>(),
+    initialized: new Subject<void>(),
+    firstPage: vi.fn().mockName("MatPaginator.firstPage"),
+    pageIndex: 0,
+    pageSize: 25,
+    length: 0,
+  }) as unknown as MatPaginator;
+
+describe("BundlesComponent", () => {
+  // Initialize TestBed for component testing
+  initializeTestBed();
+
+  let component: BundlesComponent;
+  let fixture: ComponentFixture<BundlesComponent>;
+  let bundlesService: BundlesService;
+  let sharedService: SharedMethodsService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BundlesComponent],
+      imports: [
+        NoopAnimationsModule,
+        MatCardModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatPaginatorModule,
+        MatProgressSpinnerModule,
+        MatSnackBarModule,
+        MatTableModule,
+      ],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BundlesComponent);
+    component = fixture.componentInstance;
+    bundlesService = TestBed.inject(BundlesService);
+    sharedService = TestBed.inject(SharedMethodsService);
+    // Mock the service to prevent ngOnInit from making real HTTP calls
+    vi.spyOn(bundlesService, "getDistributionInfo").mockReturnValue(
+      of(mockDistribution)
+    );
+  });
+
+  it("should create", () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it("should load bundles and distribution details on init", () => {
+    fixture.detectChanges();
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.isError).toBe(false);
+    expect(component.bundlesData.data).toEqual(mockDistribution.bundles);
+    expect(component.warnings).toEqual(mockDistribution.warnings);
+    expect(component.errors).toEqual(mockDistribution.errors);
+  });
+
+  it("should build the distribution summary from the response", () => {
+    const fields = BUNDLES_LABELS.DISTRIBUTION_FIELDS;
+    expect(component.buildDistributionSummary(mockDistribution)).toEqual([
+      { label: fields.APPLICATION_NAME, value: "Nuxeo Platform" },
+      { label: fields.APPLICATION_VERSION, value: "2025.1.0" },
+      { label: fields.DISTRIBUTION_NAME, value: "server" },
+      { label: fields.DISTRIBUTION_VERSION, value: "2025.1.0" },
+      { label: fields.DISTRIBUTION_DATE, value: "2025-01-15 10:23" },
+    ]);
+  });
+
+  it("should fall back to a placeholder for missing distribution details", () => {
+    const summary = component.buildDistributionSummary(
+      {} as DistributionResponse
+    );
+    summary.forEach((field) => {
+      expect(field.value).toBe(BUNDLES_LABELS.NOT_AVAILABLE);
+    });
+  });
+
+  it("should treat a response without bundles as no data", () => {
+    vi.spyOn(bundlesService, "getDistributionInfo").mockReturnValue(
+      of({} as DistributionResponse)
+    );
+    component.getBundles();
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.bundlesData.data).toEqual([]);
+    expect(component.warnings).toEqual([]);
+    expect(component.errors).toEqual([]);
+    expect(component.hasBundles()).toBe(false);
+  });
+
+  it("should show the error modal when fetching the distribution fails", () => {
+    const mockError = new HttpErrorResponse({
+      error: { status: 500, message: "Server error" },
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+    vi.spyOn(bundlesService, "getDistributionInfo").mockReturnValue(
+      throwError(() => mockError)
+    );
+    const showErrorSpy = vi
+      .spyOn(sharedService, "showActionErrorModal")
+      .mockReturnValue(of(undefined));
+    component.getBundles();
+    expect(component.isDataLoaded).toBe(true);
+    expect(component.isError).toBe(true);
+    expect(showErrorSpy).toHaveBeenCalledWith({
+      type: ERROR_TYPES.SERVER_ERROR,
+      details: {
+        status: 500,
+        message: "Server error",
+      },
+    });
+  });
+
+  it("should fall back to the outer status and message when the error body is empty", () => {
+    const mockError = {
+      error: null,
+      status: 503,
+      message: "Service Unavailable",
+    };
+    vi.spyOn(bundlesService, "getDistributionInfo").mockReturnValue(
+      throwError(() => mockError)
+    );
+    const showErrorSpy = vi
+      .spyOn(sharedService, "showActionErrorModal")
+      .mockReturnValue(of(undefined));
+    component.getBundles();
+    expect(showErrorSpy).toHaveBeenCalledWith({
+      type: ERROR_TYPES.SERVER_ERROR,
+      details: {
+        status: 503,
+        message: "Service Unavailable",
+      },
+    });
+  });
+
+  it("should filter bundles by name, version and revision", () => {
+    component.getBundles();
+
+    component.applyFilter({
+      target: { value: "  PICTURE  " },
+    } as unknown as Event);
+    expect(component.bundlesData.filteredData).toEqual([
+      mockDistribution.bundles[1],
+    ]);
+
+    component.applyFilter({ target: { value: "abc1234" } } as unknown as Event);
+    expect(component.bundlesData.filteredData).toEqual([
+      mockDistribution.bundles[0],
+    ]);
+
+    component.applyFilter({ target: { value: "2025.1.0" } } as unknown as Event);
+    expect(component.bundlesData.filteredData).toEqual(
+      mockDistribution.bundles
+    );
+  });
+
+  it("should filter the table when the user edits the filter input", () => {
+    fixture.detectChanges();
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector("#bundles-filter");
+    input.value = "picture";
+    input.dispatchEvent(new Event("input"));
+    fixture.detectChanges();
+    expect(component.bundlesData.filteredData).toEqual([
+      mockDistribution.bundles[1],
+    ]);
+  });
+
+  it("should report when no bundle matches the applied filter", () => {
+    component.getBundles();
+    component.applyFilter({ target: { value: "unknown" } } as unknown as Event);
+    expect(component.hasFilteredBundles()).toBe(false);
+  });
+
+  it("should reset the paginator to the first page when the filter changes", () => {
+    component.getBundles();
+    const paginator = createPaginatorStub();
+    component.bundlesData.paginator = paginator;
+    component.applyFilter({ target: { value: "core" } } as unknown as Event);
+    expect(paginator.firstPage).toHaveBeenCalled();
+  });
+
+  it("should attach the paginator to the data source once it is rendered", () => {
+    const paginator = createPaginatorStub();
+    component.tablePaginator = paginator;
+    expect(component.bundlesData.paginator).toBe(paginator);
+  });
+
+  it("should interpolate counts into labels", () => {
+    expect(
+      component.buildLabelWithCount(BUNDLES_LABELS.BUNDLES_COUNT, 12)
+    ).toBe("Bundles (12)");
+  });
+
+  it("should complete destroy$ subject on ngOnDestroy", () => {
+    const nextSpy = vi.spyOn(component.destroy$, "next");
+    const completeSpy = vi.spyOn(component.destroy$, "complete");
+    component.ngOnDestroy();
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+});

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.ts
@@ -25,8 +25,8 @@ import { ERROR_TYPES } from "../sub-features/generic-multi-feature-layout/generi
   standalone: false,
 })
 export class BundlesComponent implements OnInit, OnDestroy {
-  private bundlesService = inject(BundlesService);
-  private sharedService = inject(SharedMethodsService);
+  private readonly bundlesService = inject(BundlesService);
+  private readonly sharedService = inject(SharedMethodsService);
   BUNDLES_LABELS = BUNDLES_LABELS;
   columnsToDisplay = BUNDLES_TABLE_COLUMNS;
   pageSize = BUNDLES_PAGE_SIZE;

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.component.ts
@@ -1,0 +1,129 @@
+import { Component, OnDestroy, OnInit, ViewChild, inject } from "@angular/core";
+import { HttpErrorResponse } from "@angular/common/http";
+import { MatPaginator } from "@angular/material/paginator";
+import { MatTableDataSource } from "@angular/material/table";
+import { Subject, takeUntil } from "rxjs";
+import { BundlesService } from "./services/bundles.service";
+import {
+  BUNDLES_LABELS,
+  BUNDLES_PAGE_SIZE,
+  BUNDLES_PAGE_SIZE_OPTIONS,
+  BUNDLES_TABLE_COLUMNS,
+} from "./bundles.constants";
+import {
+  BundleInfo,
+  DistributionMessage,
+  DistributionResponse,
+} from "../../shared/types/bundles.interface";
+import { SharedMethodsService } from "../../shared/services/shared-methods.service";
+import { ERROR_TYPES } from "../sub-features/generic-multi-feature-layout/generic-multi-feature-layout.constants";
+
+@Component({
+  selector: "app-bundles",
+  templateUrl: "./bundles.component.html",
+  styleUrls: ["./bundles.component.scss"],
+  standalone: false,
+})
+export class BundlesComponent implements OnInit, OnDestroy {
+  private bundlesService = inject(BundlesService);
+  private sharedService = inject(SharedMethodsService);
+  BUNDLES_LABELS = BUNDLES_LABELS;
+  columnsToDisplay = BUNDLES_TABLE_COLUMNS;
+  pageSize = BUNDLES_PAGE_SIZE;
+  pageSizeOptions = BUNDLES_PAGE_SIZE_OPTIONS;
+  bundlesData: MatTableDataSource<BundleInfo> =
+    new MatTableDataSource<BundleInfo>([]);
+  distributionSummary: { label: string; value: string }[] = [];
+  warnings: DistributionMessage[] = [];
+  errors: DistributionMessage[] = [];
+  destroy$: Subject<void> = new Subject<void>();
+  isDataLoaded = false;
+  isError = false;
+
+  /* The table is rendered conditionally, so the paginator is only available
+  once the data has been fetched successfully. */
+  @ViewChild(MatPaginator) set tablePaginator(paginator: MatPaginator) {
+    if (paginator) {
+      this.bundlesData.paginator = paginator;
+    }
+  }
+
+  constructor() {
+    this.bundlesData.filterPredicate = (bundle: BundleInfo, filter: string) =>
+      [bundle?.name, bundle?.version, bundle?.revision]
+        .filter((field): field is string => !!field)
+        .some((field) => field.toLowerCase().includes(filter));
+  }
+
+  ngOnInit(): void {
+    this.getBundles();
+  }
+
+  getBundles(): void {
+    this.isDataLoaded = false;
+    this.isError = false;
+    this.bundlesService
+      .getDistributionInfo()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (data: DistributionResponse) => {
+          this.bundlesData.data = data?.bundles || [];
+          this.bundlesData.filter = "";
+          this.distributionSummary = this.buildDistributionSummary(data);
+          this.warnings = data?.warnings || [];
+          this.errors = data?.errors || [];
+          this.isDataLoaded = true;
+        },
+        error: (error: HttpErrorResponse) => {
+          this.isDataLoaded = true;
+          this.isError = true;
+          this.sharedService.showActionErrorModal({
+            type: ERROR_TYPES.SERVER_ERROR,
+            details: {
+              status: error?.error?.status || error?.status,
+              message: error?.error?.message || error?.message,
+            },
+          });
+        },
+      });
+  }
+
+  buildDistributionSummary(
+    data: DistributionResponse
+  ): { label: string; value: string }[] {
+    const fields = BUNDLES_LABELS.DISTRIBUTION_FIELDS;
+    return [
+      { label: fields.APPLICATION_NAME, value: data?.applicationName },
+      { label: fields.APPLICATION_VERSION, value: data?.applicationVersion },
+      { label: fields.DISTRIBUTION_NAME, value: data?.distributionName },
+      { label: fields.DISTRIBUTION_VERSION, value: data?.distributionVersion },
+      { label: fields.DISTRIBUTION_DATE, value: data?.distributionDate },
+    ].map((field) => ({
+      label: field.label,
+      value: field.value || BUNDLES_LABELS.NOT_AVAILABLE,
+    }));
+  }
+
+  applyFilter(event: Event): void {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.bundlesData.filter = filterValue.trim().toLowerCase();
+    this.bundlesData.paginator?.firstPage();
+  }
+
+  buildLabelWithCount(label: string, count: number): string {
+    return label.replaceAll("{count}", count.toString());
+  }
+
+  hasBundles(): boolean {
+    return this.bundlesData.data.length > 0;
+  }
+
+  hasFilteredBundles(): boolean {
+    return this.bundlesData.filteredData.length > 0;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.constants.ts
@@ -1,0 +1,33 @@
+export const BUNDLES_LABELS = {
+  TITLE: "Bundles",
+  DISTRIBUTION_TITLE: "Distribution",
+  BUNDLES_COUNT: "Bundles ({count})",
+  API_FAILURE_MESSAGE: "An error occurred while fetching data from the server.",
+  RETRY_BTN_LABEL: "Retry",
+  NO_DATA_MSG: "Bundle details are not available.",
+  NO_MATCHING_BUNDLES_MSG: "No bundles match the applied filter.",
+  LOADING_MSG: "Loading data...",
+  FILTER_LABEL: "Filter bundles",
+  FILTER_PLACEHOLDER: "Name, version or revision",
+  NOT_AVAILABLE: "N/A",
+  DISTRIBUTION_FIELDS: {
+    APPLICATION_NAME: "Application name",
+    APPLICATION_VERSION: "Application version",
+    DISTRIBUTION_NAME: "Distribution name",
+    DISTRIBUTION_VERSION: "Distribution version",
+    DISTRIBUTION_DATE: "Distribution date",
+  },
+  COLUMN_HEADERS: {
+    NAME: "Name",
+    VERSION: "Version",
+    REVISION: "Revision",
+  },
+  WARNINGS_TITLE: "Warnings ({count})",
+  ERRORS_TITLE: "Errors ({count})",
+};
+
+export const BUNDLES_TABLE_COLUMNS = ["name", "version", "revision"];
+
+export const BUNDLES_PAGE_SIZE = 25;
+
+export const BUNDLES_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.module.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/bundles.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatPaginatorModule } from "@angular/material/paginator";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatTableModule } from "@angular/material/table";
+import { BundlesComponent } from "./bundles.component";
+import { BundlesRoutingModule } from "./bundles-routing.module";
+
+@NgModule({
+  declarations: [BundlesComponent],
+  imports: [
+    CommonModule,
+    BundlesRoutingModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatProgressSpinnerModule,
+    MatTableModule,
+  ],
+})
+export class BundlesModule {}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.spec.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.spec.ts
@@ -1,0 +1,56 @@
+import { initializeTestBed } from "src/test-helpers"; //This import must be the first import in the file.
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockedObject,
+  vi,
+} from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import { BundlesService } from "./bundles.service";
+import { NetworkService } from "../../../shared/services/network.service";
+import { REST_END_POINTS } from "../../../shared/constants/rest-end-ponts.constants";
+
+describe("BundlesService", () => {
+  // Initialize TestBed for component testing
+  initializeTestBed();
+
+  let service: BundlesService;
+  let networkService: MockedObject<NetworkService>;
+
+  beforeEach(() => {
+    const spy = {
+      makeHttpRequest: vi.fn().mockName("NetworkService.makeHttpRequest"),
+    };
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        BundlesService,
+        { provide: NetworkService, useValue: spy },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(BundlesService);
+    networkService = TestBed.inject(
+      NetworkService
+    ) as MockedObject<NetworkService>;
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should call makeHttpRequest with the correct endpoint when getDistributionInfo is called", () => {
+    service.getDistributionInfo();
+    expect(networkService.makeHttpRequest).toHaveBeenCalledWith(
+      REST_END_POINTS.GET_DISTRIBUTION_INFO
+    );
+  });
+});

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, inject } from "@angular/core";
+import { Observable } from "rxjs";
+import { DistributionResponse } from "../../../shared/types/bundles.interface";
+import { REST_END_POINTS } from "../../../shared/constants/rest-end-ponts.constants";
+import { NetworkService } from "../../../shared/services/network.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class BundlesService {
+  private networkService = inject(NetworkService);
+
+  getDistributionInfo(): Observable<DistributionResponse> {
+    return this.networkService.makeHttpRequest<DistributionResponse>(
+      REST_END_POINTS.GET_DISTRIBUTION_INFO
+    );
+  }
+}

--- a/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/features/bundles/services/bundles.service.ts
@@ -8,7 +8,7 @@ import { NetworkService } from "../../../shared/services/network.service";
   providedIn: "root",
 })
 export class BundlesService {
-  private networkService = inject(NetworkService);
+  private readonly networkService = inject(NetworkService);
 
   getDistributionInfo(): Observable<DistributionResponse> {
     return this.networkService.makeHttpRequest<DistributionResponse>(

--- a/nuxeo-admin-console-web/angular-app/src/app/layouts/menu-bar/menu-bar.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/layouts/menu-bar/menu-bar.constants.ts
@@ -61,6 +61,12 @@ export const ADMIN_MENU: Menu[] = [
     path: "configuration-properties",
     isSelected: false,
   },
+  {
+    id: 10,
+    name: "Bundles",
+    path: "bundles",
+    isSelected: false,
+  },
 ];
 
 export const ROUTES_TITLE = {
@@ -72,4 +78,5 @@ export const ROUTES_TITLE = {
   PICTURE_RENDITIONS: "Picture Renditions",
   STREAM_MANAGEMENT: "Stream Management",
   CONFIGURATION_DETAILS: "Configuration Properties",
+  BUNDLES: "Bundles",
 };

--- a/nuxeo-admin-console-web/angular-app/src/app/shared/constants/rest-end-ponts.constants.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/shared/constants/rest-end-ponts.constants.ts
@@ -24,6 +24,7 @@ export const REST_END_POINTS = {
   GET_SCALING_ANALYSIS: "GET_SCALING_ANALYSIS",
   GET_STREAM_PROCESSOR_INFO: "GET_STREAM_PROCESSOR_INFO",
   GET_CONFIGURATION_DETAILS: "GET_CONFIGURATION_DETAILS",
+  GET_DISTRIBUTION_INFO: "GET_DISTRIBUTION_INFO",
 } as const;
 
 type RestEndpointKey = keyof typeof REST_END_POINTS;
@@ -136,6 +137,11 @@ export const REST_END_POINT_CONFIG: Record<
 
   GET_CONFIGURATION_DETAILS: {
     endpoint: "/management/configuration",
+    method: "GET",
+  },
+
+  GET_DISTRIBUTION_INFO: {
+    endpoint: "/management/distribution",
     method: "GET",
   },
 };

--- a/nuxeo-admin-console-web/angular-app/src/app/shared/types/bundles.interface.ts
+++ b/nuxeo-admin-console-web/angular-app/src/app/shared/types/bundles.interface.ts
@@ -1,0 +1,22 @@
+export interface BundleInfo {
+  name: string;
+  version: string;
+  /** Only exposed by the server for bundles built from a source revision. */
+  revision?: string;
+}
+
+export interface DistributionMessage {
+  message: string;
+}
+
+export interface DistributionResponse {
+  "entity-type"?: string;
+  applicationName: string;
+  applicationVersion: string;
+  distributionName: string;
+  distributionVersion: string;
+  distributionDate: string;
+  bundles: BundleInfo[];
+  warnings: DistributionMessage[];
+  errors: DistributionMessage[];
+}


### PR DESCRIPTION
Jira: [NAC-432](https://hyland.atlassian.net/browse/NAC-432)

## Summary

Adds a **Bundles** page so administrators can inspect the bundles deployed on a running instance from the Admin Console instead of falling back to the legacy JSF UI.

The page reads `GET /management/distribution` and renders:

- a **Distribution** card (application name/version, distribution name/version/date)
- a **Bundles** table (name, version, revision) with pagination and a client-side filter
- **Warnings** and **Errors** cards, each shown only when the server reports any

Loading, error and no-data states are all handled; the error state offers a retry and raises the shared server-error modal.

## Notes for reviewers

- **No store slice.** The data is read-only and used by one page, so this follows the `configuration-properties` pattern of a plain service call with `isDataLoaded` / `isError` flags rather than adding NgRx actions/reducers/effects.
- **Response shape** was taken from the platform's `SimplifiedServerInfoJsonWriter` rather than inferred from a sample payload. That is where the optional `revision` field comes from: the server only writes it for bundles built from a source revision (in practice, Studio packages), so the column falls back to `N/A`.
- **`distributionDate` is displayed verbatim.** The platform returns it as a free-form framework property that can even be the literal string `unknown`, so parsing it risked rendering an incorrect date. The legacy JSF page also showed it raw.
- **Filter is bound to `(input)`, not `(keyup)`**, so it also reacts to paste, autofill and clearing. A DOM-level test dispatches the real event to pin this down.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes: 875 tests across 66 files (16 new, covering the service endpoint, the load/error/no-data paths, the distribution summary fallbacks, filtering and paginator wiring)
- [x] `npm run build` succeeds, with `bundles-module` emitted as its own lazy chunk
- [x] Verified manually against a live Nuxeo instance reporting 128 bundles:
  - [x] Distribution card, table, paginator (`1 – 25 of 128`) and `Warnings (7)` render; no Errors card when the server reports zero
  - [x] Filtering `ecm.core` narrows to 22 rows and resets the paginator to page 1
  - [x] A non-matching term shows "No bundles match the applied filter." with a `0 of 0` paginator
  - [x] Clearing the filter restores all 128 bundles
  - [x] Revision column populates for Studio bundles
  - [x] `Bundles` appears in the left navigation and no console errors occur

Made with [Cursor](https://cursor.com)