### PR TITLE
NAC-468: Enforce SonarCloud quality gate and post analysis summary on PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -106,44 +106,40 @@ jobs:
           {
             echo '<!-- sonarcloud-analysis-report -->'
             echo
+            # The heading and the table already state the result, so only the
+            # non-passing cases get a line of prose, and only to say what to do next.
             case "$GATE_STATUS" in
               OK)
                 echo '## ✅ SonarCloud Quality Gate Passed'
-                echo
-                echo 'The analysis of the new code in this pull request meets every quality gate condition.'
                 ;;
               ERROR)
                 echo '## ❌ SonarCloud Quality Gate Failed'
                 echo
-                echo 'The new code in this pull request does not meet the quality gate. This check is blocking.'
+                echo 'This check is blocking. Fix the failing conditions below before merging.'
                 ;;
               *)
                 echo '## ⚠️ SonarCloud Quality Gate Status Unavailable'
                 echo
-                echo 'The quality gate result could not be retrieved. The analysis may have failed before'
-                echo 'reaching SonarCloud — check the job logs for details.'
+                echo 'The analysis may have failed before reaching SonarCloud — check the job logs.'
                 ;;
             esac
             echo
-            # The scope column is explicit on every row: the quality gate only
-            # judges new code, so presenting an overall figure without saying so
-            # would read as if the whole project were being gated.
-            echo '| Metric | Scope | Value |'
-            echo '|--------|-------|-------|'
-            echo "| **Coverage** | New code (gated) | $(fmt '%' "$NEW_COVERAGE") |"
-            echo "| **Coverage** | Whole project (informational) | $(fmt '%' "$OVERALL_COVERAGE") |"
-            echo "| **Issues** | New code (gated) | $(fmt '' "$NEW_VIOLATIONS") |"
-            echo "| **Duplicated lines** | New code (gated) | $(fmt '%' "$NEW_DUPLICATION") |"
-            echo "| **Security hotspots reviewed** | New code (gated) | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
-            echo
-            echo "Whole-project coverage is shown for context only — this quality gate judges new code. The 80% overall threshold is enforced separately by the \`utest\` check."
+            # Scope is carried in the row label rather than a column: it varies on
+            # one row only, so a column would repeat the same value four times.
+            echo '| Metric | Value |'
+            echo '|--------|-------|'
+            echo "| **Coverage (new code)** | $(fmt '%' "$NEW_COVERAGE") |"
+            echo "| **Coverage (overall)** | $(fmt '%' "$OVERALL_COVERAGE") |"
+            echo "| **New issues** | $(fmt '' "$NEW_VIOLATIONS") |"
+            echo "| **Duplicated lines (new code)** | $(fmt '%' "$NEW_DUPLICATION") |"
+            echo "| **Security hotspots reviewed (new code)** | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
             echo
 
             # SonarCloud omits new_coverage / new_duplicated_lines_density entirely when
             # a PR adds no analysable lines. Say why the table is empty rather than
             # leaving "n/a" looking like a broken lookup.
             if [ "$NEW_LINES" = "-" ] || [ "$NEW_LINES" = "0" ]; then
-              echo 'ℹ️ This pull request adds no new analysable lines of code, so SonarCloud reports no new-code coverage or duplication figures.'
+              echo 'ℹ️ No new analysable lines in this pull request, so new-code metrics are empty.'
               echo
             fi
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -79,7 +79,7 @@ jobs:
           }
 
           STATUS_JSON=$(api "${SONARCLOUD_URL}/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}") || STATUS_JSON=''
-          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_lines,new_coverage,coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
+          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_coverage,coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
 
           GATE_STATUS=$(echo "$STATUS_JSON" | jq -r '.projectStatus.status // "UNKNOWN"' 2>/dev/null || echo 'UNKNOWN')
 
@@ -91,7 +91,6 @@ jobs:
               2>/dev/null || echo '-'
           }
 
-          NEW_LINES=$(measure new_lines)
           NEW_COVERAGE=$(measure new_coverage)
           # Overall coverage has no new-code period, so `measure` falls through to `.value`.
           OVERALL_COVERAGE=$(measure coverage)
@@ -99,18 +98,26 @@ jobs:
           NEW_DUPLICATION=$(measure new_duplicated_lines_density)
           HOTSPOTS_REVIEWED=$(measure new_security_hotspots_reviewed)
 
+          # Single definition of "SonarCloud did not report this measure", so the
+          # explanatory note below fires on exactly the values that render as n/a.
+          missing() {
+            [ -z "$1" ] || [ "$1" = "-" ] || [ "$1" = "null" ]
+          }
+
           fmt() {
-            if [ -z "$2" ] || [ "$2" = "-" ] || [ "$2" = "null" ]; then echo "_n/a_"; else echo "$2$1"; fi
+            if missing "$2"; then echo "_n/a_"; else echo "$2$1"; fi
           }
 
           {
             echo '<!-- sonarcloud-analysis-report -->'
             echo
-            # The heading and the table already state the result, so only the
-            # non-passing cases get a line of prose, and only to say what to do next.
+            # Each heading gets one line of prose and no more: what the result
+            # means when it passes, what to do next when it does not.
             case "$GATE_STATUS" in
               OK)
                 echo '## ✅ SonarCloud Quality Gate Passed'
+                echo
+                echo 'The analysis of the new code in this pull request meets every quality gate condition.'
                 ;;
               ERROR)
                 echo '## ❌ SonarCloud Quality Gate Failed'
@@ -135,11 +142,13 @@ jobs:
             echo "| **Security hotspots reviewed (new code)** | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
             echo
 
-            # SonarCloud omits new_coverage / new_duplicated_lines_density entirely when
-            # a PR adds no analysable lines. Say why the table is empty rather than
-            # leaving "n/a" looking like a broken lookup.
-            if [ "$NEW_LINES" = "-" ] || [ "$NEW_LINES" = "0" ]; then
-              echo 'ℹ️ No new analysable lines in this pull request, so new-code metrics are empty.'
+            # Keyed off the coverage value rather than new_lines: a PR whose new
+            # lines are all uncoverable (templates, config) has new_lines > 0 yet
+            # still no new_coverage, and a bare n/a reads as a broken lookup.
+            # Deliberately says nothing about duplication, which SonarCloud does
+            # report for those same files and so is usually present here.
+            if missing "$NEW_COVERAGE"; then
+              echo 'ℹ️ No new-code coverage to report — this pull request adds no coverable lines (either none at all, or only files like templates and config).'
               echo
             fi
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -79,7 +79,7 @@ jobs:
           }
 
           STATUS_JSON=$(api "${SONARCLOUD_URL}/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}") || STATUS_JSON=''
-          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
+          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_lines,new_coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
 
           GATE_STATUS=$(echo "$STATUS_JSON" | jq -r '.projectStatus.status // "UNKNOWN"' 2>/dev/null || echo 'UNKNOWN')
 
@@ -91,6 +91,7 @@ jobs:
               2>/dev/null || echo '-'
           }
 
+          NEW_LINES=$(measure new_lines)
           NEW_COVERAGE=$(measure new_coverage)
           NEW_VIOLATIONS=$(measure new_violations)
           NEW_DUPLICATION=$(measure new_duplicated_lines_density)
@@ -129,6 +130,14 @@ jobs:
             echo "| **Duplicated lines** | $(fmt '%' "$NEW_DUPLICATION") |"
             echo "| **Security hotspots reviewed** | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
             echo
+
+            # SonarCloud omits new_coverage / new_duplicated_lines_density entirely when
+            # a PR adds no analysable lines. Say why the table is empty rather than
+            # leaving "n/a" looking like a broken lookup.
+            if [ "$NEW_LINES" = "-" ] || [ "$NEW_LINES" = "0" ]; then
+              echo 'ℹ️ This pull request adds no new analysable lines of code, so SonarCloud reports no new-code coverage or duplication figures.'
+              echo
+            fi
 
             FAILED_CONDITIONS=$(echo "$STATUS_JSON" | jq -r '
               [.projectStatus.conditions[]? | select(.status == "ERROR")

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -79,7 +79,7 @@ jobs:
           }
 
           STATUS_JSON=$(api "${SONARCLOUD_URL}/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}") || STATUS_JSON=''
-          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_lines,new_coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
+          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_lines,new_coverage,coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
 
           GATE_STATUS=$(echo "$STATUS_JSON" | jq -r '.projectStatus.status // "UNKNOWN"' 2>/dev/null || echo 'UNKNOWN')
 
@@ -93,6 +93,8 @@ jobs:
 
           NEW_LINES=$(measure new_lines)
           NEW_COVERAGE=$(measure new_coverage)
+          # Overall coverage has no new-code period, so `measure` falls through to `.value`.
+          OVERALL_COVERAGE=$(measure coverage)
           NEW_VIOLATIONS=$(measure new_violations)
           NEW_DUPLICATION=$(measure new_duplicated_lines_density)
           HOTSPOTS_REVIEWED=$(measure new_security_hotspots_reviewed)
@@ -123,12 +125,18 @@ jobs:
                 ;;
             esac
             echo
-            echo '| Metric (new code) | Value |'
-            echo '|-------------------|-------|'
-            echo "| **Coverage** | $(fmt '%' "$NEW_COVERAGE") |"
-            echo "| **New issues** | $(fmt '' "$NEW_VIOLATIONS") |"
-            echo "| **Duplicated lines** | $(fmt '%' "$NEW_DUPLICATION") |"
-            echo "| **Security hotspots reviewed** | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
+            # The scope column is explicit on every row: the quality gate only
+            # judges new code, so presenting an overall figure without saying so
+            # would read as if the whole project were being gated.
+            echo '| Metric | Scope | Value |'
+            echo '|--------|-------|-------|'
+            echo "| **Coverage** | New code (gated) | $(fmt '%' "$NEW_COVERAGE") |"
+            echo "| **Coverage** | Whole project (informational) | $(fmt '%' "$OVERALL_COVERAGE") |"
+            echo "| **Issues** | New code (gated) | $(fmt '' "$NEW_VIOLATIONS") |"
+            echo "| **Duplicated lines** | New code (gated) | $(fmt '%' "$NEW_DUPLICATION") |"
+            echo "| **Security hotspots reviewed** | New code (gated) | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
+            echo
+            echo "Whole-project coverage is shown for context only — this quality gate judges new code. The 80% overall threshold is enforced separately by the \`utest\` check."
             echo
 
             # SonarCloud omits new_coverage / new_duplicated_lines_density entirely when

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -50,6 +50,12 @@ jobs:
       # it the step only proves the report was uploaded, never that it passed.
       # `continue-on-error` keeps the job alive so the summary comment is still posted;
       # the "Enforce quality gate result" step below turns a red gate into a red job.
+      #
+      # The pull request parameters are passed explicitly rather than left to the
+      # scanner's autodetection, which was recording every pull request against
+      # `main`. The gate was therefore measuring new code as the diff against
+      # `main` even for pull requests targeting `dev`, counting anything already
+      # merged to `dev` as new. Same shape as nuxeo-web-ui's sonar.yaml.
       - name: SonarCloud Scan
         id: sonar-scan
         continue-on-error: true
@@ -58,8 +64,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
+          # Not github.workspace: our Angular app lives in a subdirectory.
           projectBaseDir: nuxeo-admin-console-web/angular-app
-          args: -Dsonar.qualitygate.wait=true
+          args: >
+            -Dsonar.qualitygate.wait=true
+            ${{ github.event_name == 'pull_request' &&
+              format('-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2}',
+                github.event.pull_request.number,
+                github.event.pull_request.head.ref,
+                github.event.pull_request.base.ref)
+              || format('-Dsonar.branch.name={0}', github.ref_name) }}
 
       - name: Build SonarCloud summary
         id: sonar-summary

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,11 +15,17 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  # Deliberately not named SONAR_HOST_URL: that variable is consumed by
+  # sonarqube-scan-action and setting it would change how the scanner is configured.
+  SONARCLOUD_URL: https://sonarcloud.io
+  SONAR_PROJECT_KEY: nuxeo_nuxeo-admin-console-ui
+
 jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,10 +45,156 @@ jobs:
         working-directory: nuxeo-admin-console-web/angular-app
         run: npm test
 
+      # `sonar.qualitygate.wait=true` makes the scanner block until SonarCloud has
+      # finished computing the quality gate and exit non-zero when it fails. Without
+      # it the step only proves the report was uploaded, never that it passed.
+      # `continue-on-error` keeps the job alive so the summary comment is still posted;
+      # the "Enforce quality gate result" step below turns a red gate into a red job.
       - name: SonarCloud Scan
+        id: sonar-scan
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: nuxeo-admin-console-web/angular-app
+          args: -Dsonar.qualitygate.wait=true
+
+      - name: Build SonarCloud summary
+        id: sonar-summary
+        if: always() && github.event_name == 'pull_request'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SCAN_OUTCOME: ${{ steps.sonar-scan.outcome }}
+        run: |
+          set -uo pipefail
+
+          DASHBOARD_URL="${SONARCLOUD_URL}/summary/new_code?id=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}"
+          BODY_FILE="$RUNNER_TEMP/sonar-comment.md"
+
+          api() {
+            curl -sS -u "${SONAR_TOKEN}:" "$1"
+          }
+
+          STATUS_JSON=$(api "${SONARCLOUD_URL}/api/qualitygates/project_status?projectKey=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}") || STATUS_JSON=''
+          MEASURES_JSON=$(api "${SONARCLOUD_URL}/api/measures/component?component=${SONAR_PROJECT_KEY}&pullRequest=${PR_NUMBER}&metricKeys=new_coverage,new_violations,new_duplicated_lines_density,new_security_hotspots_reviewed") || MEASURES_JSON=''
+
+          GATE_STATUS=$(echo "$STATUS_JSON" | jq -r '.projectStatus.status // "UNKNOWN"' 2>/dev/null || echo 'UNKNOWN')
+
+          # SonarCloud returns new-code measures either under `period.value` or the
+          # legacy `periods[0].value`; fall back to the plain value as a last resort.
+          measure() {
+            echo "$MEASURES_JSON" | jq -r --arg m "$1" \
+              '(.component.measures[]? | select(.metric == $m) | .period.value // .periods[0].value // .value) // "-"' \
+              2>/dev/null || echo '-'
+          }
+
+          NEW_COVERAGE=$(measure new_coverage)
+          NEW_VIOLATIONS=$(measure new_violations)
+          NEW_DUPLICATION=$(measure new_duplicated_lines_density)
+          HOTSPOTS_REVIEWED=$(measure new_security_hotspots_reviewed)
+
+          fmt() {
+            if [ -z "$2" ] || [ "$2" = "-" ] || [ "$2" = "null" ]; then echo "_n/a_"; else echo "$2$1"; fi
+          }
+
+          {
+            echo '<!-- sonarcloud-analysis-report -->'
+            echo
+            case "$GATE_STATUS" in
+              OK)
+                echo '## ✅ SonarCloud Quality Gate Passed'
+                echo
+                echo 'The analysis of the new code in this pull request meets every quality gate condition.'
+                ;;
+              ERROR)
+                echo '## ❌ SonarCloud Quality Gate Failed'
+                echo
+                echo 'The new code in this pull request does not meet the quality gate. This check is blocking.'
+                ;;
+              *)
+                echo '## ⚠️ SonarCloud Quality Gate Status Unavailable'
+                echo
+                echo 'The quality gate result could not be retrieved. The analysis may have failed before'
+                echo 'reaching SonarCloud — check the job logs for details.'
+                ;;
+            esac
+            echo
+            echo '| Metric (new code) | Value |'
+            echo '|-------------------|-------|'
+            echo "| **Coverage** | $(fmt '%' "$NEW_COVERAGE") |"
+            echo "| **New issues** | $(fmt '' "$NEW_VIOLATIONS") |"
+            echo "| **Duplicated lines** | $(fmt '%' "$NEW_DUPLICATION") |"
+            echo "| **Security hotspots reviewed** | $(fmt '%' "$HOTSPOTS_REVIEWED") |"
+            echo
+
+            FAILED_CONDITIONS=$(echo "$STATUS_JSON" | jq -r '
+              [.projectStatus.conditions[]? | select(.status == "ERROR")
+                | "- `\(.metricKey)`: **\(.actualValue)** (fails when \(.comparator | ascii_downcase | sub("^lt$"; "<") | sub("^gt$"; ">")) **\(.errorThreshold)**)"]
+              | join("\n")' 2>/dev/null || echo '')
+
+            if [ -n "$FAILED_CONDITIONS" ]; then
+              echo '### 🔧 Failing conditions'
+              echo
+              echo "$FAILED_CONDITIONS"
+              echo
+            fi
+
+            # The gate can be green while the scan step still failed (scanner crash,
+            # upload error, wait timeout). Say so, otherwise the red check looks unexplained.
+            if [ "$GATE_STATUS" = "OK" ] && [ "$SCAN_OUTCOME" != "success" ]; then
+              echo '> ⚠️ The quality gate passed but the scan step itself failed. Check the job logs.'
+              echo
+            fi
+
+            echo "📊 [View the full analysis on SonarCloud]($DASHBOARD_URL)"
+          } > "$BODY_FILE"
+
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+          echo "gate_status=$GATE_STATUS" >> "$GITHUB_OUTPUT"
+          cat "$BODY_FILE" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR with SonarCloud results
+        if: always() && github.event_name == 'pull_request' && steps.sonar-summary.outputs.body_file != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('${{ steps.sonar-summary.outputs.body_file }}', 'utf8');
+
+            // Find existing bot comment to update instead of creating new ones
+            const botCommentIdentifier = '<!-- sonarcloud-analysis-report -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(botCommentIdentifier)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Enforce quality gate result
+        if: steps.sonar-scan.outcome != 'success'
+        run: |
+          echo "❌ SonarCloud analysis did not pass: the quality gate failed or the scan itself errored."
+          echo "See the summary comment on the pull request and the 'SonarCloud Scan' step logs above."
+          exit 1

--- a/.github/workflows/utest.yaml
+++ b/.github/workflows/utest.yaml
@@ -134,12 +134,8 @@ jobs:
           {
             if [ "$FAILED" = true ]; then
               echo "## ❌ Test Coverage Failed"
-              echo
-              echo "Some coverage metrics are below the **${THRESHOLD}%** threshold."
             else
               echo "## ✅ Test Coverage Passed"
-              echo
-              echo "All coverage metrics meet the **${THRESHOLD}%** threshold."
             fi
             echo
             echo '| Metric (overall) | Coverage | Status | Threshold |'

--- a/.github/workflows/utest.yaml
+++ b/.github/workflows/utest.yaml
@@ -3,8 +3,6 @@ name: Unit-test
 permissions:
   # Read access for code checkout and test execution
   contents: read
-  # Write access needed to post PR comments with coverage results
-  pull-requests: write
   
 on:
   pull_request:
@@ -88,6 +86,11 @@ jobs:
           # Check if coverage summary exists
           if [ ! -f coverage/admin_console_ui/coverage-summary.json ]; then
             echo "❌ Coverage report not found"
+            {
+              echo '## ❌ Test Coverage'
+              echo
+              echo "No coverage report was produced at \`coverage/admin_console_ui/coverage-summary.json\`."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
           
@@ -105,26 +108,44 @@ jobs:
           # Check if any coverage is below threshold
           THRESHOLD=80
           FAILED=false
+          TABLE_ROWS=""
           
-          if (( $(echo "$STATEMENTS < $THRESHOLD" | bc -l) )); then
-            echo "statements_failed=true" >> $GITHUB_OUTPUT
-            FAILED=true
-          fi
+          # Gates one metric and collects its row for the job summary. Runs in the
+          # current shell, so assignments to FAILED / TABLE_ROWS are visible below.
+          check_metric() {
+            local label="$1" key="$2" value="$3"
+            if (( $(echo "$value < $THRESHOLD" | bc -l) )); then
+              echo "${key}_failed=true" >> $GITHUB_OUTPUT
+              FAILED=true
+              TABLE_ROWS="${TABLE_ROWS}| **${label}** | ${value}% | ❌ Failed | ${THRESHOLD}% |"$'\n'
+            else
+              TABLE_ROWS="${TABLE_ROWS}| **${label}** | ${value}% | ✅ Passed | ${THRESHOLD}% |"$'\n'
+            fi
+          }
           
-          if (( $(echo "$BRANCHES < $THRESHOLD" | bc -l) )); then
-            echo "branches_failed=true" >> $GITHUB_OUTPUT
-            FAILED=true
-          fi
+          check_metric Statements statements "$STATEMENTS"
+          check_metric Branches branches "$BRANCHES"
+          check_metric Functions functions "$FUNCTIONS"
+          check_metric Lines lines "$LINES"
           
-          if (( $(echo "$FUNCTIONS < $THRESHOLD" | bc -l) )); then
-            echo "functions_failed=true" >> $GITHUB_OUTPUT
-            FAILED=true
-          fi
-          
-          if (( $(echo "$LINES < $THRESHOLD" | bc -l) )); then
-            echo "lines_failed=true" >> $GITHUB_OUTPUT
-            FAILED=true
-          fi
+          # Overall coverage is reported in the job summary rather than as a PR
+          # comment: the SonarCloud workflow already posts a single summary comment
+          # that carries both new-code and overall coverage.
+          {
+            if [ "$FAILED" = true ]; then
+              echo "## ❌ Test Coverage Failed"
+              echo
+              echo "Some coverage metrics are below the **${THRESHOLD}%** threshold."
+            else
+              echo "## ✅ Test Coverage Passed"
+              echo
+              echo "All coverage metrics meet the **${THRESHOLD}%** threshold."
+            fi
+            echo
+            echo '| Metric (overall) | Coverage | Status | Threshold |'
+            echo '|------------------|----------|--------|-----------|'
+            printf '%s' "$TABLE_ROWS"
+          } >> "$GITHUB_STEP_SUMMARY"
           
           if [ "$FAILED" = true ]; then
             echo "coverage_passed=false" >> $GITHUB_OUTPUT
@@ -132,95 +153,6 @@ jobs:
           else
             echo "coverage_passed=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Comment PR with coverage results
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const statements = '${{ steps.coverage-check.outputs.statements }}';
-            const branches = '${{ steps.coverage-check.outputs.branches }}';
-            const functions = '${{ steps.coverage-check.outputs.functions }}';
-            const lines = '${{ steps.coverage-check.outputs.lines }}';
-            const coveragePassed = '${{ steps.coverage-check.outputs.coverage_passed }}' === 'true';
-            const threshold = 80;
-            
-            const statementsFailed = '${{ steps.coverage-check.outputs.statements_failed }}' === 'true';
-            const branchesFailed = '${{ steps.coverage-check.outputs.branches_failed }}' === 'true';
-            const functionsFailed = '${{ steps.coverage-check.outputs.functions_failed }}' === 'true';
-            const linesFailed = '${{ steps.coverage-check.outputs.lines_failed }}' === 'true';
-            
-            const getIcon = (value, failed) => {
-              if (failed) return '❌';
-              return parseFloat(value) >= 90 ? '✅' : '⚠️';
-            };
-            
-            // Find existing bot comment to update instead of creating new ones
-            const botCommentIdentifier = '<!-- vitest-coverage-report -->';
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const existingComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && comment.body.includes(botCommentIdentifier)
-            );
-            
-            let comment = botCommentIdentifier + '\n\n';
-            
-            // Show coverage status
-            if (coveragePassed) {
-              comment += `## ✅ Test Coverage Passed\n\n`;
-              comment += `All coverage metrics meet the **${threshold}%** threshold!\n\n`;
-            } else {
-              comment += `## ❌ Test Coverage Failed\n\n`;
-              comment += `Some coverage metrics are below the **${threshold}%** threshold.\n\n`;
-            }
-            
-            comment += `| Metric | Coverage | Status | Threshold |\n`;
-            comment += `|--------|----------|--------|----------|\n`;
-            comment += `| **Statements** | ${statements}% | ${getIcon(statements, statementsFailed)} ${statementsFailed ? 'Failed' : 'Passed'} | ${threshold}% |\n`;
-            comment += `| **Branches** | ${branches}% | ${getIcon(branches, branchesFailed)} ${branchesFailed ? 'Failed' : 'Passed'} | ${threshold}% |\n`;
-            comment += `| **Functions** | ${functions}% | ${getIcon(functions, functionsFailed)} ${functionsFailed ? 'Failed' : 'Passed'} | ${threshold}% |\n`;
-            comment += `| **Lines** | ${lines}% | ${getIcon(lines, linesFailed)} ${linesFailed ? 'Failed' : 'Passed'} | ${threshold}% |\n\n`;
-            
-            if (!coveragePassed) {
-              comment += `### 🔧 Action Required\n\n`;
-              comment += `Please add tests to improve coverage for the following metrics:\n\n`;
-              if (statementsFailed) {
-                comment += `- **Statements**: Currently ${statements}%, needs ${(threshold - parseFloat(statements)).toFixed(2)}% more coverage\n`;
-              }
-              if (branchesFailed) {
-                comment += `- **Branches**: Currently ${branches}%, needs ${(threshold - parseFloat(branches)).toFixed(2)}% more coverage\n`;
-              }
-              if (functionsFailed) {
-                comment += `- **Functions**: Currently ${functions}%, needs ${(threshold - parseFloat(functions)).toFixed(2)}% more coverage\n`;
-              }
-              if (linesFailed) {
-                comment += `- **Lines**: Currently ${lines}%, needs ${(threshold - parseFloat(lines)).toFixed(2)}% more coverage\n`;
-              }
-              comment += `\n📊 View detailed coverage report in the build artifacts.\n`;
-            } else {
-              comment += `🎉 Great job maintaining high test coverage!\n`;
-            }
-            
-            // Update existing comment or create new one
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: comment
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: comment
-              });
-            }
 
       - name: Fail workflow if coverage failed
         if: steps.coverage-check.outputs.coverage_passed != 'true'


### PR DESCRIPTION
Jira: [NAC-468](https://hyland.atlassian.net/browse/NAC-468)

## Summary

`SonarCloud Scan` never verified anything. The scanner uploaded the report and exited `0` while SonarCloud computed the quality gate asynchronously, so a green check only ever meant *"an analysis was submitted"*. On #333 all six checks were green while the gate was `FAILED` on `new_reliability_rating` (C against a required A).

This PR makes the scan wait for the verdict, fail the job when the gate is red, and post a single sticky summary comment with the gate result and the key metrics. It also removes the duplicate vitest coverage comment, so a PR now carries one bot comment instead of two, and fixes the branch parameters so the gate measures the right diff.

Two CI files, no application code: `.github/workflows/sonarcloud.yml` and `.github/workflows/utest.yaml`.

## How it works

- `-Dsonar.qualitygate.wait=true` makes the scanner block until the gate is computed and exit non-zero when it fails.
- The scan step runs with `continue-on-error: true` and a trailing `Enforce quality gate result` step fails the job. This ordering matters: a step that fails normally aborts the job, which would skip the comment and leave reviewers with a red check and no explanation.
- The comment is sticky via the `<!-- sonarcloud-analysis-report -->` marker and updated in place, so repeated pushes don't stack up comments.
- Commenting is limited to `pull_request` events. Pushes to `main`/`dev` still scan and still enforce the gate.
- `utest.yaml` no longer posts a coverage comment; its table goes to the job summary instead. Its 80% threshold enforcement is unchanged — that was always the check step's own `exit 1`, never the comment step.

## Branch parameters

The scanner was previously invoked with no branch or pull request parameters, so SonarCloud recorded every PR's base as `main` regardless of its real target. Since all feature work targets `dev`, the gate was judging "new code" as the diff against `main`, meaning work already merged to `dev` counted as new in every PR.

This PR passes them explicitly, matching the pattern used in `nuxeo-web-ui`: `-Dsonar.pullrequest.key/branch/base` on `pull_request`, and `-Dsonar.branch.name` on `push`.

**Known limitation, resolved on merge.** SonarCloud currently has only one analysed branch for this project — `main`, last analysed in February. There is no `dev` branch for it to diff against, so it still falls back to `main` even though the scanner is now sending `base=dev` (confirmed in the runner log). The `-Dsonar.branch.name=dev` argument on push is what registers `dev` with SonarCloud, so merging this PR creates it and PRs opened afterwards will scope correctly. Worth verifying after merge that `dev` appears in the project's branch list.

## Branch protection

Already applied: `SonarCloud Scan`, `lint` and `utest` are required status checks on `dev` and `main`. `main` additionally has "require branches to be up to date before merging" enabled.

One consequence worth knowing: Dependabot PRs cannot read `secrets.SONAR_TOKEN`, so `SonarCloud Scan` can never pass on them. The open Dependabot PRs will need an admin merge, which works because `enforce_admins` is off on both branches.

## Test plan

- [x] All checks green on this PR, with the summary comment posted.
- [x] Sticky update proven: the comment kept its ID across pushes and only its `updated_at` moved.
- [x] Coverage threshold verified to still exit `1` below 80% and `0` above.
- [x] Red gate verified end to end on a throwaway PR (now closed): a deliberate unlabelled-input bug failed the gate on `new_reliability_rating`, `Enforce quality gate result` turned the check red, and the comment was still posted with the failing condition named.
- [x] Branch parameters confirmed reaching the scanner in the runner log.
- [ ] After merge: `dev` appears in SonarCloud's branch list, and the next PR records `base: dev`.
- [ ] After merge: a push to `dev` still scans and skips commenting.
